### PR TITLE
Add AI classification and gallery-style web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+*.pyc
+gallery_data.json
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "-m", "gallery_organiser", "serve"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Gallery Organiser Starter Pack v2
+
+This repository provides a minimal starting point for building a gallery
+organiser application. It includes simple data models for artworks, a
+command line interface for adding and listing pieces, and a React-based web
+interface for browsing media files.
+
+## Features
+
+- Data models using Python dataclasses
+- Command line interface for adding and listing artworks
+- Web interface built with React for browsing media files
+- Built-in file browser to navigate folders and preview images
+- AI-powered image classification to label photos automatically
+- Basic unit tests
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run tests**
+
+   ```bash
+   pytest
+   ```
+
+3. **Use the CLI**
+
+   ```bash
+   python -m gallery_organiser add --title "Starry Night" --artist "Vincent van Gogh" --year 1889
+   python -m gallery_organiser list
+   ```
+
+4. **Launch the web UI**
+
+   ```bash
+   python -m gallery_organiser serve
+   ```
+
+   Then open <http://127.0.0.1:5000> in your browser. Use the built-in file
+   browser to pick a directory and view a gallery-style grid of images with
+   automatic labels.
+
+You can check the installed version with:
+
+```bash
+python -m gallery_organiser --version
+```
+
+Artworks are stored in `gallery_data.json` in the project root.
+
+## License
+
+This project is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ interface for browsing media files.
 - Built-in file browser to navigate folders and preview images
 - AI-powered image classification to label photos automatically
 - Basic unit tests
+- Optional Docker support for containerised deployment
+
+The updated React frontend provides a modern two-panel layout similar to
+popular online converters, making navigation through folders and viewing
+thumbnails more intuitive.
 
 ## Getting Started
 
@@ -44,6 +49,15 @@ interface for browsing media files.
    Then open <http://127.0.0.1:5000> in your browser. Use the built-in file
    browser to pick a directory and view a gallery-style grid of images with
    automatic labels.
+
+5. **Run with Docker**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   This builds an image with all dependencies installed and serves the
+   application on <http://127.0.0.1:5000>.
 
 You can check the installed version with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  gallery:
+    build: .
+    ports:
+      - "5000:5000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,13 +6,20 @@
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <style>
-      body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
-      header { background: #222; color: #fff; padding: 10px; }
-      .toolbar { padding: 10px; background: #f0f0f0; }
-      .dirs button { margin: 4px; }
-      .grid { display: flex; flex-wrap: wrap; gap: 10px; padding: 10px; }
+      body { margin: 0; font-family: Arial, sans-serif; background: #f8f9fa; }
+      header { background: #1e293b; color: #fff; padding: 16px; text-align: center; }
+      .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+      .browser { display: flex; gap: 20px; }
+      .sidebar { width: 220px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; }
+      .sidebar h2 { font-size: 16px; margin-top: 0; }
+      .sidebar ul { list-style: none; padding: 0; margin: 0; }
+      .sidebar li { padding: 6px 8px; cursor: pointer; border-radius: 4px; }
+      .sidebar li:hover { background: #f0f0f0; }
+      .main { flex: 1; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; }
+      .pathbar { margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
+      .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }
       .item { text-align: center; }
-      .item img { width: 200px; height: 200px; object-fit: cover; border-radius: 4px; }
+      .item img { width: 180px; height: 180px; object-fit: cover; border-radius: 4px; }
       .label { margin-top: 4px; font-size: 14px; }
     </style>
   </head>
@@ -43,18 +50,27 @@
 
         return e(React.Fragment, null,
           e('header', null, e('h1', null, 'Gallery Organiser')),
-          e('div', { className: 'toolbar' },
-            e('button', { onClick: goUp }, 'Up'),
-            e('span', { style: { marginLeft: '8px' } }, path)
-          ),
-          e('div', { className: 'dirs' },
-            dirs.map((d) => e('button', { key: d, onClick: () => setPath(d) }, d))
-          ),
-          e('div', { className: 'grid' },
-            files.map((f) => e('div', { key: f.path, className: 'item' },
-              e('img', { src: `/api/file?path=${encodeURIComponent(f.path)}` }),
-              f.label ? e('div', { className: 'label' }, f.label) : null
-            ))
+          e('div', { className: 'container' },
+            e('div', { className: 'browser' },
+              e('div', { className: 'sidebar' },
+                e('h2', null, 'Folders'),
+                e('button', { onClick: goUp }, 'Up'),
+                e('ul', null,
+                  dirs.map((d) => e('li', { key: d, onClick: () => setPath(d) }, d))
+                )
+              ),
+              e('div', { className: 'main' },
+                e('div', { className: 'pathbar' },
+                  e('span', null, path)
+                ),
+                e('div', { className: 'grid' },
+                  files.map((f) => e('div', { key: f.path, className: 'item' },
+                    e('img', { src: `/api/file?path=${encodeURIComponent(f.path)}` }),
+                    f.label ? e('div', { className: 'label' }, f.label) : null
+                  ))
+                )
+              )
+            )
           )
         );
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Gallery Organiser</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+      header { background: #222; color: #fff; padding: 10px; }
+      .toolbar { padding: 10px; background: #f0f0f0; }
+      .dirs button { margin: 4px; }
+      .grid { display: flex; flex-wrap: wrap; gap: 10px; padding: 10px; }
+      .item { text-align: center; }
+      .item img { width: 200px; height: 200px; object-fit: cover; border-radius: 4px; }
+      .label { margin-top: 4px; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      const e = React.createElement;
+      function App() {
+        const [path, setPath] = React.useState('/');
+        const [dirs, setDirs] = React.useState([]);
+        const [files, setFiles] = React.useState([]);
+
+        const load = React.useCallback(() => {
+          fetch(`/api/dirs?path=${encodeURIComponent(path)}`)
+            .then((r) => r.json())
+            .then(setDirs);
+          fetch(`/api/media?path=${encodeURIComponent(path)}`)
+            .then((r) => r.json())
+            .then(setFiles);
+        }, [path]);
+        React.useEffect(load, [load]);
+
+        const goUp = () => {
+          if (path === '/') return;
+          const parent = path.replace(/\/$/, '').split('/').slice(0, -1).join('/') || '/';
+          setPath(parent);
+        };
+
+        return e(React.Fragment, null,
+          e('header', null, e('h1', null, 'Gallery Organiser')),
+          e('div', { className: 'toolbar' },
+            e('button', { onClick: goUp }, 'Up'),
+            e('span', { style: { marginLeft: '8px' } }, path)
+          ),
+          e('div', { className: 'dirs' },
+            dirs.map((d) => e('button', { key: d, onClick: () => setPath(d) }, d))
+          ),
+          e('div', { className: 'grid' },
+            files.map((f) => e('div', { key: f.path, className: 'item' },
+              e('img', { src: `/api/file?path=${encodeURIComponent(f.path)}` }),
+              f.label ? e('div', { className: 'label' }, f.label) : null
+            ))
+          )
+        );
+      }
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(e(App));
+    </script>
+  </body>
+</html>

--- a/gallery_organiser/__init__.py
+++ b/gallery_organiser/__init__.py
@@ -1,0 +1,9 @@
+"""Gallery organiser package."""
+
+from .models import Artwork, Gallery
+from .media import scan_media
+
+__version__ = "2.0.0"
+
+__all__ = ["Artwork", "Gallery", "scan_media", "__version__"]
+

--- a/gallery_organiser/__main__.py
+++ b/gallery_organiser/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gallery_organiser/classifier.py
+++ b/gallery_organiser/classifier.py
@@ -1,0 +1,58 @@
+"""Image classification utilities using a pre-trained ResNet model.
+
+The classifier lazily loads the model on first use to avoid import costs
+when image classification is not required. If any part of the loading or
+classification fails, the function returns ``"unknown"`` so callers can
+handle environments without the necessary ML dependencies.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+
+try:  # pragma: no cover - heavy dependency optional
+    import torch
+    from torchvision.models import resnet18, ResNet18_Weights
+except Exception:  # pragma: no cover - fall back when torch is missing
+    torch = None  # type: ignore
+
+_model = None
+_transform = None
+_labels: List[str] = []
+
+
+def _load_model() -> None:
+    """Load the pre-trained model and preprocessing transforms."""
+    global _model, _transform, _labels
+    if torch is None:  # pragma: no cover - torch not available
+        return
+    weights = ResNet18_Weights.DEFAULT
+    _model = resnet18(weights=weights)
+    _model.eval()
+    _transform = weights.transforms()
+    _labels = weights.meta.get("categories", [])
+
+
+def classify_image(path: Path) -> str:
+    """Return the best-guess label for the image at *path*.
+
+    If the model or dependencies are unavailable, ``"unknown"`` is
+    returned instead of raising an exception.
+    """
+    try:
+        if _model is None:
+            _load_model()
+        if _model is None or torch is None:
+            return "unknown"
+        img = Image.open(path).convert("RGB")
+        tensor = _transform(img).unsqueeze(0)
+        with torch.no_grad():
+            preds = _model(tensor)[0]
+        idx = int(preds.argmax())
+        if 0 <= idx < len(_labels):
+            return _labels[idx]
+    except Exception:  # pragma: no cover - best effort only
+        pass
+    return "unknown"

--- a/gallery_organiser/cli.py
+++ b/gallery_organiser/cli.py
@@ -1,0 +1,73 @@
+"""Command line interface for the gallery organiser."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from . import __version__
+from .models import Artwork, Gallery
+
+DATA_FILE = Path("gallery_data.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create an argument parser for the CLI.
+
+    Split out for easier testing and to avoid global parser state.
+    """
+    parser = argparse.ArgumentParser(description="Gallery organiser CLI")
+    parser.add_argument("command", choices=["add", "list", "serve"])
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument("--name", default="My Gallery")
+    parser.add_argument("--title")
+    parser.add_argument("--artist")
+    parser.add_argument("--year", type=int)
+    return parser
+
+
+def load_gallery(name: str) -> Gallery:
+    """Load gallery data from disk if available."""
+    if DATA_FILE.exists():
+        data = json.loads(DATA_FILE.read_text())
+        artworks = [Artwork(**a) for a in data.get("artworks", [])]
+        return Gallery(name=name, artworks=artworks)
+    return Gallery(name=name)
+
+
+def save_gallery(gallery: Gallery) -> None:
+    """Persist gallery data to disk."""
+    data = {
+        "name": gallery.name,
+        "artworks": [a.__dict__ for a in gallery.artworks],
+    }
+    DATA_FILE.write_text(json.dumps(data, indent=2))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command in {"add", "list"}:
+        gallery = load_gallery(args.name)
+
+    if args.command == "add":
+        if not args.title or not args.artist:
+            parser.error("add requires --title and --artist")
+        artwork = Artwork(title=args.title, artist=args.artist, year=args.year)
+        gallery.add_artwork(artwork)
+        save_gallery(gallery)
+        print(f"Added artwork '{artwork.title}' by {artwork.artist}")
+    elif args.command == "list":
+        for art in gallery.list_artworks():
+            yr = art.year if art.year is not None else "Unknown year"
+            print(f"{art.title} by {art.artist} ({yr})")
+    else:
+        from .server import run_server
+        run_server()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gallery_organiser/media.py
+++ b/gallery_organiser/media.py
@@ -1,0 +1,45 @@
+"""Utilities for scanning and classifying media files on disk."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from .classifier import classify_image
+
+MEDIA_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".bmp",
+    ".heic",
+    ".mp4",
+    ".mov",
+    ".mkv",
+}
+
+IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".bmp",
+    ".heic",
+}
+
+
+def scan_media(directory: Path) -> List[Dict[str, str]]:
+    """Return media files found under *directory* recursively.
+
+    Each item in the returned list contains a ``path`` key. Images include
+    an additional ``label`` key populated by the classifier.
+    """
+
+    files: List[Dict[str, str]] = []
+    for path in directory.rglob("*"):
+        if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS:
+            info: Dict[str, str] = {"path": str(path)}
+            if path.suffix.lower() in IMAGE_EXTENSIONS:
+                info["label"] = classify_image(path)
+            files.append(info)
+    return files

--- a/gallery_organiser/models.py
+++ b/gallery_organiser/models.py
@@ -1,0 +1,30 @@
+"""Data models for the gallery organiser."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Artwork:
+    """Represents a piece of art."""
+
+    title: str
+    artist: str
+    year: int | None = None
+
+
+@dataclass
+class Gallery:
+    """A simple in-memory gallery."""
+
+    name: str
+    artworks: List[Artwork] = field(default_factory=list)
+
+    def add_artwork(self, artwork: Artwork) -> None:
+        """Add an artwork to the gallery."""
+        self.artworks.append(artwork)
+
+    def list_artworks(self) -> List[Artwork]:
+        """Return the artworks currently stored."""
+        return list(self.artworks)

--- a/gallery_organiser/server.py
+++ b/gallery_organiser/server.py
@@ -1,0 +1,70 @@
+"""Flask-based web interface for browsing media files."""
+from __future__ import annotations
+
+from pathlib import Path
+import io
+from flask import Flask, jsonify, request, send_from_directory, send_file, abort
+from PIL import Image
+try:
+    import pillow_heif
+    pillow_heif.register_heif_opener()  # enable HEIC support if installed
+except Exception:  # pragma: no cover - pillow-heif is optional
+    pass
+
+from .media import scan_media
+
+STATIC_DIR = Path(__file__).resolve().parents[1] / "frontend"
+app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="")
+
+
+@app.get("/api/media")
+def api_media() -> object:
+    """Return media files under a given directory as JSON.
+
+    Each item includes the file ``path`` and, for images, a ``label`` from
+    the classifier.
+    """
+    path_str = request.args.get("path", ".")
+    files = scan_media(Path(path_str))
+    return jsonify(files)
+
+
+@app.get("/api/dirs")
+def api_dirs() -> object:
+    """Return subdirectories for *path* as JSON."""
+    path_str = request.args.get("path", ".")
+    directory = Path(path_str)
+    dirs = [str(p) for p in directory.iterdir() if p.is_dir()]
+    return jsonify(dirs)
+
+
+@app.get("/api/file")
+def api_file() -> object:
+    """Send a media file to the browser.
+
+    HEIC images are converted to JPEG on the fly for browser compatibility.
+    """
+    path_str = request.args.get("path")
+    if not path_str:
+        abort(400)
+    path = Path(path_str)
+    if not path.exists():
+        abort(404)
+    if path.suffix.lower() == ".heic":
+        with Image.open(path) as img:
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG")
+            buf.seek(0)
+            return send_file(buf, mimetype="image/jpeg")
+    return send_file(path)
+
+
+@app.route("/")
+def index() -> object:
+    """Serve the React application."""
+    return send_from_directory(app.static_folder, "index.html")
+
+
+def run_server() -> None:
+    """Run the development server."""
+    app.run(debug=True)

--- a/gallery_organiser/server.py
+++ b/gallery_organiser/server.py
@@ -67,4 +67,4 @@ def index() -> object:
 
 def run_server() -> None:
     """Run the development server."""
-    app.run(debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pytest>=7.0
+Flask
+Pillow
+pillow-heif
+torch
+torchvision

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser import cli, server
+
+
+def test_serve_command_invokes_run_server(monkeypatch):
+    called = {}
+
+    def fake_run_server():
+        called['ran'] = True
+
+    monkeypatch.setattr(server, 'run_server', fake_run_server)
+    cli.main(['serve'])
+    assert called.get('ran') is True
+
+
+def test_version_flag(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(['--version'])
+    assert '2.0.0' in capsys.readouterr().out

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser import media
+
+
+def test_scan_media(tmp_path, monkeypatch):
+    (tmp_path / "image.jpg").write_text("a")
+    (tmp_path / "video.mp4").write_text("a")
+    (tmp_path / "photo.heic").write_text("a")
+    (tmp_path / "doc.txt").write_text("a")
+
+    monkeypatch.setattr(media, "classify_image", lambda p: "label")
+    files = media.scan_media(tmp_path)
+    names = sorted(Path(f["path"]).name for f in files)
+    labels = [f.get("label") for f in files if f.get("label")]
+    assert names == ["image.jpg", "photo.heic", "video.mp4"]
+    assert labels == ["label", "label"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is on the path when running tests directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser.models import Artwork, Gallery
+
+
+def test_add_and_list_artwork():
+    gallery = Gallery(name="Test")
+    art = Artwork(title="Mona Lisa", artist="Leonardo da Vinci", year=1503)
+    gallery.add_artwork(art)
+
+    artworks = gallery.list_artworks()
+    assert len(artworks) == 1
+    assert artworks[0].title == "Mona Lisa"
+    assert artworks[0].artist == "Leonardo da Vinci"
+    assert artworks[0].year == 1503

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,30 @@
+from gallery_organiser import server
+from PIL import Image
+
+def test_api_dirs(tmp_path):
+    (tmp_path / "sub").mkdir()
+    client = server.app.test_client()
+    resp = client.get("/api/dirs", query_string={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    assert str(tmp_path / "sub") in resp.get_json()
+
+
+def test_api_file(tmp_path):
+    img_path = tmp_path / "pic.png"
+    Image.new("RGB", (1, 1)).save(img_path)
+    client = server.app.test_client()
+    resp = client.get("/api/file", query_string={"path": str(img_path)})
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+
+
+def test_api_media(monkeypatch, tmp_path):
+    def fake_scan_media(path):
+        return [{"path": str(tmp_path / "img.jpg"), "label": "cat"}]
+
+    monkeypatch.setattr(server, "scan_media", fake_scan_media)
+    client = server.app.test_client()
+    resp = client.get("/api/media", query_string={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["label"] == "cat"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,3 +28,14 @@ def test_api_media(monkeypatch, tmp_path):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data[0]["label"] == "cat"
+
+
+def test_run_server_uses_public_host(monkeypatch):
+    called = {}
+
+    def fake_run(*args, **kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(server.app, "run", fake_run)
+    server.run_server()
+    assert called.get("host") == "0.0.0.0"


### PR DESCRIPTION
## Summary
- classify images with a lazily-loaded ResNet model and expose labels in the media API
- render a gallery-style grid in the React frontend showing AI-generated labels
- document AI features, enhanced browsing, and package versioning in the README

## Testing
- `pip install -r requirements.txt` *(fails: heavy torch download; Flask/Pillow installed separately)*
- `pytest`
- `python -m gallery_organiser --version`
- `python -m gallery_organiser add --title "Test" --artist "Tester"`
- `python -m gallery_organiser list`
- `python -m gallery_organiser serve` (stopped after startup)


------
https://chatgpt.com/codex/tasks/task_e_689b6e4dfaa08327b1baaac9e228d829