### PR TITLE
Handle inaccessible files and show scan progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+*.pyc
+gallery_data.json
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "-m", "gallery_organiser", "serve"]

--- a/README.md
+++ b/README.md
@@ -11,15 +11,18 @@ interface for browsing media files.
 - Command line interface for adding and listing artworks
 - Web interface built with React for browsing media files
 - Built-in file browser to navigate folders and preview images
-- AI-powered image classification to label photos automatically
-- Shows scanning progress and reports skipped items when directories are
-  inaccessible
+- AI-powered image classification using a Hugging Face model
+- Optional face detection with tagging and name-based search
+- Scanning starts only when confirmed and shows a log console of activity
+- Labels and face tags are stored in a SQLite database for later lookup
+- Shows scanning progress and reports skipped items when directories are inaccessible
 - Basic unit tests
 - Optional Docker support for containerised deployment
 
-The updated React frontend provides a modern two-panel layout similar to
-popular online converters, making navigation through folders and viewing
-thumbnails more intuitive.
+The React frontend provides a modern two-panel layout. Select a folder,
+click **Scan**, and thumbnails with predicted labels will appear. The log
+console at the bottom records scanning activity. You can tag detected faces
+and later search by person name.
 
 ## Getting Started
 
@@ -49,9 +52,11 @@ thumbnails more intuitive.
    ```
 
    Then open <http://127.0.0.1:5000> in your browser. Use the built-in file
-   browser to pick a directory and view a gallery-style grid of images with
-   automatic labels. The UI indicates scanning progress and lists any
-   inaccessible files that were skipped.
+   browser to pick a directory, press **Scan**, and view a gallery-style grid
+   of images with automatic labels. The log console records progress and any
+   inaccessible files that were skipped. Use the **Tag** button on an image to
+   associate a detected face with a name, then search for tagged people with
+   the search box.
 
 5. **Run with Docker**
 
@@ -68,7 +73,8 @@ You can check the installed version with:
 python -m gallery_organiser --version
 ```
 
-Artworks are stored in `gallery_data.json` in the project root.
+Artworks are stored in `gallery_data.json` in the project root. Labels and
+face tags are kept in `gallery.db`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Gallery Organiser Starter Pack v2
+
+This repository provides a minimal starting point for building a gallery
+organiser application. It includes simple data models for artworks, a
+command line interface for adding and listing pieces, and a React-based web
+interface for browsing media files.
+
+## Features
+
+- Data models using Python dataclasses
+- Command line interface for adding and listing artworks
+- Web interface built with React for browsing media files
+- Built-in file browser to navigate folders and preview images
+- AI-powered image classification to label photos automatically
+- Shows scanning progress and reports skipped items when directories are
+  inaccessible
+- Basic unit tests
+- Optional Docker support for containerised deployment
+
+The updated React frontend provides a modern two-panel layout similar to
+popular online converters, making navigation through folders and viewing
+thumbnails more intuitive.
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run tests**
+
+   ```bash
+   pytest
+   ```
+
+3. **Use the CLI**
+
+   ```bash
+   python -m gallery_organiser add --title "Starry Night" --artist "Vincent van Gogh" --year 1889
+   python -m gallery_organiser list
+   ```
+
+4. **Launch the web UI**
+
+   ```bash
+   python -m gallery_organiser serve
+   ```
+
+   Then open <http://127.0.0.1:5000> in your browser. Use the built-in file
+   browser to pick a directory and view a gallery-style grid of images with
+   automatic labels. The UI indicates scanning progress and lists any
+   inaccessible files that were skipped.
+
+5. **Run with Docker**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   This builds an image with all dependencies installed and serves the
+   application on <http://127.0.0.1:5000>.
+
+You can check the installed version with:
+
+```bash
+python -m gallery_organiser --version
+```
+
+Artworks are stored in `gallery_data.json` in the project root.
+
+## License
+
+This project is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ interface for browsing media files.
 - Scanning starts only when confirmed and shows a log console of activity
 - Labels and face tags are stored in a SQLite database for later lookup
 - Shows scanning progress and reports skipped items when directories are inaccessible
+- Scanning runs in a background Celery task with detailed progress and a summary of discovered labels
 - Basic unit tests
 - Optional Docker support for containerised deployment
 
@@ -50,13 +51,20 @@ and later search by person name.
    ```bash
    python -m gallery_organiser serve
    ```
+   
+   In another terminal you can start a worker to process scan tasks
+   asynchronously:
+
+   ```bash
+   celery -A gallery_organiser.tasks worker --loglevel=info
+   ```
 
    Then open <http://127.0.0.1:5000> in your browser. Use the built-in file
-   browser to pick a directory, press **Scan**, and view a gallery-style grid
-   of images with automatic labels. The log console records progress and any
-   inaccessible files that were skipped. Use the **Tag** button on an image to
-   associate a detected face with a name, then search for tagged people with
-   the search box.
+   browser to pick a directory, press **Scan**, and a progress bar will update
+   as files are classified in the background. When finished a summary of labels
+   is shown. The log console records progress and any inaccessible files that
+   were skipped. Use the **Tag** button on an image to associate a detected face
+   with a name, then search for tagged people with the search box.
 
 5. **Run with Docker**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  gallery:
+    build: .
+    ports:
+      - "5000:5000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,7 @@
       .item img { width: 180px; height: 180px; object-fit: cover; border-radius: 4px; }
       .label { margin-top: 4px; font-size: 14px; }
       .logs { margin-top:10px; background:#000; color:#0f0; padding:10px; height:120px; overflow:auto; font-family:monospace; }
+      .summary { margin-top:10px; }
     </style>
   </head>
   <body>
@@ -36,6 +37,9 @@
         const [logs, setLogs] = React.useState([]);
         const [loading, setLoading] = React.useState(false);
         const [query, setQuery] = React.useState('');
+        const [current, setCurrent] = React.useState(0);
+        const [total, setTotal] = React.useState(0);
+        const [summary, setSummary] = React.useState({});
 
         const loadDirs = React.useCallback(() => {
           fetch(`/api/dirs?path=${encodeURIComponent(path)}`)
@@ -47,14 +51,31 @@
 
         const scan = () => {
           setLoading(true);
-          fetch(`/api/media?path=${encodeURIComponent(path)}`)
-            .then((r) => r.json())
-            .then((data) => {
-              setFiles(data.files);
-              setSkipped(data.skipped);
-              setLogs(data.logs);
-            })
-            .finally(() => setLoading(false));
+          setFiles([]); setSkipped(0); setLogs([]); setSummary({});
+          fetch('/api/scan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path})})
+            .then(r=>r.json())
+            .then(({task_id}) => {
+              const poll = () => {
+                fetch(`/api/scan/${task_id}`)
+                  .then(r=>r.json())
+                  .then(data => {
+                    setLogs(data.logs || []);
+                    setCurrent(data.current || 0);
+                    setTotal(data.total || 0);
+                    if(data.state === 'SUCCESS') {
+                      setFiles(data.files);
+                      setSkipped(data.skipped);
+                      setSummary(data.summary || {});
+                      setLoading(false);
+                    } else if(data.state === 'FAILURE') {
+                      setLoading(false);
+                    } else {
+                      setTimeout(poll, 500);
+                    }
+                  });
+              };
+              poll();
+            });
         };
 
         const goUp = () => {
@@ -110,7 +131,17 @@
                   ))
                 ),
                 e('div', { className: 'logs' }, e('pre', null, logs.join('\n'))),
-                loading ? e('div', null, 'Loading...') : e('div', null, `${files.length} files${skipped ? ` (${skipped} skipped)` : ''}`)
+                loading ?
+                  e('div', null,
+                    e('progress', { value: current, max: total || 1, style:{width:'100%'} }),
+                    e('div', null, `${current}/${total} files`)
+                  ) :
+                  e(React.Fragment, null,
+                    e('div', null, `${files.length} files${skipped ? ` (${skipped} skipped)` : ''}`),
+                    e('div', {className:'summary'},
+                      Object.entries(summary).map(([label,count]) => e('div', {key:label}, `${label}: ${count}`))
+                    )
+                  )
               )
             )
           )

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Gallery Organiser</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <style>
+      body { margin: 0; font-family: Arial, sans-serif; background: #f8f9fa; }
+      header { background: #1e293b; color: #fff; padding: 16px; text-align: center; }
+      .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+      .browser { display: flex; gap: 20px; }
+      .sidebar { width: 220px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; }
+      .sidebar h2 { font-size: 16px; margin-top: 0; }
+      .sidebar ul { list-style: none; padding: 0; margin: 0; }
+      .sidebar li { padding: 6px 8px; cursor: pointer; border-radius: 4px; }
+      .sidebar li:hover { background: #f0f0f0; }
+      .main { flex: 1; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; }
+      .pathbar { margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
+      .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }
+      .item { text-align: center; }
+      .item img { width: 180px; height: 180px; object-fit: cover; border-radius: 4px; }
+      .label { margin-top: 4px; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      const e = React.createElement;
+      function App() {
+        const [path, setPath] = React.useState('/');
+        const [dirs, setDirs] = React.useState([]);
+        const [files, setFiles] = React.useState([]);
+        const [skipped, setSkipped] = React.useState(0);
+        const [loading, setLoading] = React.useState(false);
+
+        const load = React.useCallback(() => {
+          setLoading(true);
+          fetch(`/api/dirs?path=${encodeURIComponent(path)}`)
+            .then((r) => r.json())
+            .then(setDirs);
+          fetch(`/api/media?path=${encodeURIComponent(path)}`)
+            .then((r) => r.json())
+            .then((data) => {
+              setFiles(data.files);
+              setSkipped(data.skipped);
+            })
+            .finally(() => setLoading(false));
+        }, [path]);
+        React.useEffect(load, [load]);
+
+        const goUp = () => {
+          if (path === '/') return;
+          const parent = path.replace(/\/$/, '').split('/').slice(0, -1).join('/') || '/';
+          setPath(parent);
+        };
+
+        return e(React.Fragment, null,
+          e('header', null, e('h1', null, 'Gallery Organiser')),
+          e('div', { className: 'container' },
+            e('div', { className: 'browser' },
+              e('div', { className: 'sidebar' },
+                e('h2', null, 'Folders'),
+                e('button', { onClick: goUp }, 'Up'),
+                e('ul', null,
+                  dirs.map((d) => e('li', { key: d, onClick: () => setPath(d) }, d))
+                )
+              ),
+              e('div', { className: 'main' },
+                e('div', { className: 'pathbar' },
+                  e('span', null, path),
+                  loading
+                    ? e('span', null, 'Scanning...')
+                    : e('span', null, `${files.length} files${skipped ? ` (${skipped} skipped)` : ''}`)
+                ),
+                e('div', { className: 'grid' },
+                  files.map((f) => e('div', { key: f.path, className: 'item' },
+                    e('img', { src: `/api/file?path=${encodeURIComponent(f.path)}` }),
+                    f.label ? e('div', { className: 'label' }, f.label) : null
+                  ))
+                )
+              )
+            )
+          )
+        );
+      }
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(e(App));
+    </script>
+  </body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,12 +15,13 @@
       .sidebar ul { list-style: none; padding: 0; margin: 0; }
       .sidebar li { padding: 6px 8px; cursor: pointer; border-radius: 4px; }
       .sidebar li:hover { background: #f0f0f0; }
-      .main { flex: 1; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; }
-      .pathbar { margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
+      .main { flex: 1; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 10px; display:flex; flex-direction:column; }
+      .pathbar { margin-bottom: 10px; display: flex; gap: 8px; align-items: center; }
       .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }
       .item { text-align: center; }
       .item img { width: 180px; height: 180px; object-fit: cover; border-radius: 4px; }
       .label { margin-top: 4px; font-size: 14px; }
+      .logs { margin-top:10px; background:#000; color:#0f0; padding:10px; height:120px; overflow:auto; font-family:monospace; }
     </style>
   </head>
   <body>
@@ -32,22 +33,29 @@
         const [dirs, setDirs] = React.useState([]);
         const [files, setFiles] = React.useState([]);
         const [skipped, setSkipped] = React.useState(0);
+        const [logs, setLogs] = React.useState([]);
         const [loading, setLoading] = React.useState(false);
+        const [query, setQuery] = React.useState('');
 
-        const load = React.useCallback(() => {
-          setLoading(true);
+        const loadDirs = React.useCallback(() => {
           fetch(`/api/dirs?path=${encodeURIComponent(path)}`)
             .then((r) => r.json())
             .then(setDirs);
+        }, [path]);
+
+        React.useEffect(loadDirs, [loadDirs]);
+
+        const scan = () => {
+          setLoading(true);
           fetch(`/api/media?path=${encodeURIComponent(path)}`)
             .then((r) => r.json())
             .then((data) => {
               setFiles(data.files);
               setSkipped(data.skipped);
+              setLogs(data.logs);
             })
             .finally(() => setLoading(false));
-        }, [path]);
-        React.useEffect(load, [load]);
+        };
 
         const goUp = () => {
           if (path === '/') return;
@@ -55,30 +63,54 @@
           setPath(parent);
         };
 
+        const tag = (file) => {
+          const name = prompt('Tag name');
+          if (!name) return;
+          fetch('/api/tag', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path: file.path, name})})
+            .then(() => alert('Tagged'));
+        };
+
+        const search = () => {
+          if (!query) return;
+          setLoading(true);
+          fetch(`/api/search?name=${encodeURIComponent(query)}`)
+            .then((r) => r.json())
+            .then((data) => {
+              setFiles(data);
+              setDirs([]);
+              setLogs([`Search results for ${query}`]);
+              setSkipped(0);
+            })
+            .finally(() => setLoading(false));
+        };
+
         return e(React.Fragment, null,
           e('header', null, e('h1', null, 'Gallery Organiser')),
           e('div', { className: 'container' },
+            e('div', { className: 'pathbar' },
+              e('button', { onClick: goUp }, 'Up'),
+              e('input', { value: path, onChange: (ev) => setPath(ev.target.value), style:{flex:1} }),
+              e('button', { onClick: scan }, 'Scan'),
+              e('input', { placeholder:'Search person', value: query, onChange: e=>setQuery(e.target.value) }),
+              e('button', { onClick: search }, 'Search')
+            ),
             e('div', { className: 'browser' },
               e('div', { className: 'sidebar' },
                 e('h2', null, 'Folders'),
-                e('button', { onClick: goUp }, 'Up'),
                 e('ul', null,
                   dirs.map((d) => e('li', { key: d, onClick: () => setPath(d) }, d))
                 )
               ),
               e('div', { className: 'main' },
-                e('div', { className: 'pathbar' },
-                  e('span', null, path),
-                  loading
-                    ? e('span', null, 'Scanning...')
-                    : e('span', null, `${files.length} files${skipped ? ` (${skipped} skipped)` : ''}`)
-                ),
                 e('div', { className: 'grid' },
                   files.map((f) => e('div', { key: f.path, className: 'item' },
                     e('img', { src: `/api/file?path=${encodeURIComponent(f.path)}` }),
-                    f.label ? e('div', { className: 'label' }, f.label) : null
+                    f.label ? e('div', { className: 'label' }, f.label) : null,
+                    e('button', { onClick: () => tag(f) }, 'Tag')
                   ))
-                )
+                ),
+                e('div', { className: 'logs' }, e('pre', null, logs.join('\n'))),
+                loading ? e('div', null, 'Loading...') : e('div', null, `${files.length} files${skipped ? ` (${skipped} skipped)` : ''}`)
               )
             )
           )

--- a/gallery_organiser/__init__.py
+++ b/gallery_organiser/__init__.py
@@ -1,0 +1,9 @@
+"""Gallery organiser package."""
+
+from .models import Artwork, Gallery
+from .media import scan_media
+
+__version__ = "2.0.0"
+
+__all__ = ["Artwork", "Gallery", "scan_media", "__version__"]
+

--- a/gallery_organiser/__main__.py
+++ b/gallery_organiser/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gallery_organiser/classifier.py
+++ b/gallery_organiser/classifier.py
@@ -1,58 +1,44 @@
-"""Image classification utilities using a pre-trained ResNet model.
+"""Image classification utilities using a Hugging Face model.
 
-The classifier lazily loads the model on first use to avoid import costs
-when image classification is not required. If any part of the loading or
-classification fails, the function returns ``"unknown"`` so callers can
-handle environments without the necessary ML dependencies.
+The classifier lazily loads the model on first use to avoid heavy imports
+when classification is not required. If loading fails, ``"unknown"`` is
+returned so callers can handle environments without the ML dependencies.
 """
 from __future__ import annotations
 
 from pathlib import Path
 from typing import List
 
-from PIL import Image
-
 try:  # pragma: no cover - heavy dependency optional
-    import torch
-    from torchvision.models import resnet18, ResNet18_Weights
-except Exception:  # pragma: no cover - fall back when torch is missing
-    torch = None  # type: ignore
+    from transformers import pipeline
+except Exception:  # pragma: no cover - transformers not available
+    pipeline = None  # type: ignore
 
-_model = None
-_transform = None
-_labels: List[str] = []
+_classifier = None
 
 
 def _load_model() -> None:
-    """Load the pre-trained model and preprocessing transforms."""
-    global _model, _transform, _labels
-    if torch is None:  # pragma: no cover - torch not available
+    """Load the image classification pipeline."""
+    global _classifier
+    if pipeline is None:  # pragma: no cover - transformers missing
         return
-    weights = ResNet18_Weights.DEFAULT
-    _model = resnet18(weights=weights)
-    _model.eval()
-    _transform = weights.transforms()
-    _labels = weights.meta.get("categories", [])
+    _classifier = pipeline("image-classification")
 
 
 def classify_image(path: Path) -> str:
     """Return the best-guess label for the image at *path*.
 
-    If the model or dependencies are unavailable, ``"unknown"`` is
-    returned instead of raising an exception.
+    Falls back to ``"unknown"`` if the model or dependencies are
+    unavailable.
     """
     try:
-        if _model is None:
+        if _classifier is None:
             _load_model()
-        if _model is None or torch is None:
+        if _classifier is None:
             return "unknown"
-        img = Image.open(path).convert("RGB")
-        tensor = _transform(img).unsqueeze(0)
-        with torch.no_grad():
-            preds = _model(tensor)[0]
-        idx = int(preds.argmax())
-        if 0 <= idx < len(_labels):
-            return _labels[idx]
+        preds = _classifier(str(path))
+        if preds:
+            return preds[0]["label"]
     except Exception:  # pragma: no cover - best effort only
         pass
     return "unknown"

--- a/gallery_organiser/classifier.py
+++ b/gallery_organiser/classifier.py
@@ -1,0 +1,58 @@
+"""Image classification utilities using a pre-trained ResNet model.
+
+The classifier lazily loads the model on first use to avoid import costs
+when image classification is not required. If any part of the loading or
+classification fails, the function returns ``"unknown"`` so callers can
+handle environments without the necessary ML dependencies.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+
+try:  # pragma: no cover - heavy dependency optional
+    import torch
+    from torchvision.models import resnet18, ResNet18_Weights
+except Exception:  # pragma: no cover - fall back when torch is missing
+    torch = None  # type: ignore
+
+_model = None
+_transform = None
+_labels: List[str] = []
+
+
+def _load_model() -> None:
+    """Load the pre-trained model and preprocessing transforms."""
+    global _model, _transform, _labels
+    if torch is None:  # pragma: no cover - torch not available
+        return
+    weights = ResNet18_Weights.DEFAULT
+    _model = resnet18(weights=weights)
+    _model.eval()
+    _transform = weights.transforms()
+    _labels = weights.meta.get("categories", [])
+
+
+def classify_image(path: Path) -> str:
+    """Return the best-guess label for the image at *path*.
+
+    If the model or dependencies are unavailable, ``"unknown"`` is
+    returned instead of raising an exception.
+    """
+    try:
+        if _model is None:
+            _load_model()
+        if _model is None or torch is None:
+            return "unknown"
+        img = Image.open(path).convert("RGB")
+        tensor = _transform(img).unsqueeze(0)
+        with torch.no_grad():
+            preds = _model(tensor)[0]
+        idx = int(preds.argmax())
+        if 0 <= idx < len(_labels):
+            return _labels[idx]
+    except Exception:  # pragma: no cover - best effort only
+        pass
+    return "unknown"

--- a/gallery_organiser/cli.py
+++ b/gallery_organiser/cli.py
@@ -1,0 +1,73 @@
+"""Command line interface for the gallery organiser."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from . import __version__
+from .models import Artwork, Gallery
+
+DATA_FILE = Path("gallery_data.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create an argument parser for the CLI.
+
+    Split out for easier testing and to avoid global parser state.
+    """
+    parser = argparse.ArgumentParser(description="Gallery organiser CLI")
+    parser.add_argument("command", choices=["add", "list", "serve"])
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument("--name", default="My Gallery")
+    parser.add_argument("--title")
+    parser.add_argument("--artist")
+    parser.add_argument("--year", type=int)
+    return parser
+
+
+def load_gallery(name: str) -> Gallery:
+    """Load gallery data from disk if available."""
+    if DATA_FILE.exists():
+        data = json.loads(DATA_FILE.read_text())
+        artworks = [Artwork(**a) for a in data.get("artworks", [])]
+        return Gallery(name=name, artworks=artworks)
+    return Gallery(name=name)
+
+
+def save_gallery(gallery: Gallery) -> None:
+    """Persist gallery data to disk."""
+    data = {
+        "name": gallery.name,
+        "artworks": [a.__dict__ for a in gallery.artworks],
+    }
+    DATA_FILE.write_text(json.dumps(data, indent=2))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command in {"add", "list"}:
+        gallery = load_gallery(args.name)
+
+    if args.command == "add":
+        if not args.title or not args.artist:
+            parser.error("add requires --title and --artist")
+        artwork = Artwork(title=args.title, artist=args.artist, year=args.year)
+        gallery.add_artwork(artwork)
+        save_gallery(gallery)
+        print(f"Added artwork '{artwork.title}' by {artwork.artist}")
+    elif args.command == "list":
+        for art in gallery.list_artworks():
+            yr = art.year if art.year is not None else "Unknown year"
+            print(f"{art.title} by {art.artist} ({yr})")
+    else:
+        from .server import run_server
+        run_server()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gallery_organiser/database.py
+++ b/gallery_organiser/database.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+# Database path can be configured via GALLERY_DB environment variable
+DB_PATH = Path(os.environ.get("GALLERY_DB", Path(__file__).resolve().parents[1] / "gallery.db"))
+
+
+def init_db() -> None:
+    """Initialise the SQLite database if it doesn't exist."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS images (path TEXT PRIMARY KEY, label TEXT)"
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS faces (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            image_path TEXT,
+            name TEXT,
+            bbox TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def store_label(path: str, label: str) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("REPLACE INTO images(path, label) VALUES (?, ?)", (path, label))
+    conn.commit()
+    conn.close()
+
+
+def add_face_tag(path: str, name: str, bbox: Iterable[int]) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO faces(image_path, name, bbox) VALUES (?, ?, ?)",
+        (path, name, json.dumps(list(bbox))),
+    )
+    conn.commit()
+    conn.close()
+
+
+def search_by_name(name: str) -> List[str]:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT image_path FROM faces WHERE name = ?", (name,))
+    rows = [r[0] for r in cur.fetchall()]
+    conn.close()
+    return rows

--- a/gallery_organiser/face.py
+++ b/gallery_organiser/face.py
@@ -1,0 +1,35 @@
+"""Simple face detection utilities using OpenCV."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import cv2
+except Exception:  # pragma: no cover
+    cv2 = None  # type: ignore
+
+_cascade = None
+
+
+def _load_cascade() -> None:
+    global _cascade
+    if cv2 is None:  # pragma: no cover
+        return
+    if _cascade is None:
+        _cascade = cv2.CascadeClassifier(cv2.data.haarcascades + "haarcascade_frontalface_default.xml")
+
+
+def detect_faces(path: Path) -> List[Tuple[int, int, int, int]]:
+    """Return a list of face bounding boxes for the image at *path*."""
+    if cv2 is None:  # pragma: no cover
+        return []
+    _load_cascade()
+    if _cascade is None:
+        return []
+    img = cv2.imread(str(path))
+    if img is None:
+        return []
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    faces = _cascade.detectMultiScale(gray, 1.1, 4)
+    return [tuple(map(int, f)) for f in faces]

--- a/gallery_organiser/media.py
+++ b/gallery_organiser/media.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from .classifier import classify_image
+from .database import store_label
 
 MEDIA_EXTENSIONS = {
     ".jpg",
@@ -29,16 +30,17 @@ IMAGE_EXTENSIONS = {
 }
 
 
-def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int]:
+def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int, List[str]]:
     """Return media files found under *directory* recursively.
 
-    Returns a tuple ``(files, skipped)`` where ``files`` is a list of
-    discovered media dictionaries and ``skipped`` is the number of entries
-    that could not be accessed due to permission errors.
+    Returns a tuple ``(files, skipped, logs)`` where ``files`` is a list of
+    discovered media dictionaries, ``skipped`` is the number of entries that
+    could not be accessed, and ``logs`` contains textual activity messages.
     """
 
     files: List[Dict[str, str]] = []
     skipped = 0
+    logs: List[str] = []
 
     for root, _, filenames in os.walk(directory, onerror=lambda e: None):
         for name in filenames:
@@ -47,10 +49,15 @@ def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int]:
                 ext = path.suffix.lower()
                 if ext in MEDIA_EXTENSIONS:
                     info: Dict[str, str] = {"path": str(path)}
+                    logs.append(f"Found {path}")
                     if ext in IMAGE_EXTENSIONS:
-                        info["label"] = classify_image(path)
+                        label = classify_image(path)
+                        info["label"] = label
+                        store_label(str(path), label)
+                        logs.append(f"Classified {path} as {label}")
                     files.append(info)
             except (OSError, PermissionError):
                 skipped += 1
+                logs.append(f"Skipped {path}")
 
-    return files, skipped
+    return files, skipped, logs

--- a/gallery_organiser/media.py
+++ b/gallery_organiser/media.py
@@ -1,0 +1,56 @@
+"""Utilities for scanning and classifying media files on disk."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .classifier import classify_image
+
+MEDIA_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".bmp",
+    ".heic",
+    ".mp4",
+    ".mov",
+    ".mkv",
+}
+
+IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".bmp",
+    ".heic",
+}
+
+
+def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int]:
+    """Return media files found under *directory* recursively.
+
+    Returns a tuple ``(files, skipped)`` where ``files`` is a list of
+    discovered media dictionaries and ``skipped`` is the number of entries
+    that could not be accessed due to permission errors.
+    """
+
+    files: List[Dict[str, str]] = []
+    skipped = 0
+
+    for root, _, filenames in os.walk(directory, onerror=lambda e: None):
+        for name in filenames:
+            path = Path(root) / name
+            try:
+                ext = path.suffix.lower()
+                if ext in MEDIA_EXTENSIONS:
+                    info: Dict[str, str] = {"path": str(path)}
+                    if ext in IMAGE_EXTENSIONS:
+                        info["label"] = classify_image(path)
+                    files.append(info)
+            except (OSError, PermissionError):
+                skipped += 1
+
+    return files, skipped

--- a/gallery_organiser/media.py
+++ b/gallery_organiser/media.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from .classifier import classify_image
 from .database import store_label
@@ -30,21 +30,33 @@ IMAGE_EXTENSIONS = {
 }
 
 
-def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int, List[str]]:
+def scan_media(
+    directory: Path,
+    progress_cb: Callable[[int, int, List[str]], None] | None = None,
+) -> Tuple[List[Dict[str, str]], int, List[str], int]:
     """Return media files found under *directory* recursively.
 
-    Returns a tuple ``(files, skipped, logs)`` where ``files`` is a list of
-    discovered media dictionaries, ``skipped`` is the number of entries that
-    could not be accessed, and ``logs`` contains textual activity messages.
+    Returns a tuple ``(files, skipped, logs, total)`` where ``files`` is a list
+    of discovered media dictionaries, ``skipped`` is the number of entries that
+    could not be accessed, ``logs`` contains textual activity messages, and
+    ``total`` is the number of filesystem entries visited. When ``progress_cb``
+    is supplied it will be called with ``(current, total, recent_logs)`` for
+    every processed file allowing callers to track progress.
     """
 
     files: List[Dict[str, str]] = []
     skipped = 0
     logs: List[str] = []
 
+    total = 0
+    for _root, _dirs, filenames in os.walk(directory, onerror=lambda e: None):
+        total += len(filenames)
+
+    current = 0
     for root, _, filenames in os.walk(directory, onerror=lambda e: None):
         for name in filenames:
             path = Path(root) / name
+            current += 1
             try:
                 ext = path.suffix.lower()
                 if ext in MEDIA_EXTENSIONS:
@@ -60,4 +72,7 @@ def scan_media(directory: Path) -> Tuple[List[Dict[str, str]], int, List[str]]:
                 skipped += 1
                 logs.append(f"Skipped {path}")
 
-    return files, skipped, logs
+            if progress_cb:
+                progress_cb(current, total, logs[-10:])
+
+    return files, skipped, logs, total

--- a/gallery_organiser/models.py
+++ b/gallery_organiser/models.py
@@ -1,0 +1,30 @@
+"""Data models for the gallery organiser."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Artwork:
+    """Represents a piece of art."""
+
+    title: str
+    artist: str
+    year: int | None = None
+
+
+@dataclass
+class Gallery:
+    """A simple in-memory gallery."""
+
+    name: str
+    artworks: List[Artwork] = field(default_factory=list)
+
+    def add_artwork(self, artwork: Artwork) -> None:
+        """Add an artwork to the gallery."""
+        self.artworks.append(artwork)
+
+    def list_artworks(self) -> List[Artwork]:
+        """Return the artworks currently stored."""
+        return list(self.artworks)

--- a/gallery_organiser/server.py
+++ b/gallery_organiser/server.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import io
 from flask import Flask, jsonify, request, send_from_directory, send_file, abort
 from PIL import Image
+
 try:
     import pillow_heif
     pillow_heif.register_heif_opener()  # enable HEIC support if installed
@@ -12,9 +13,12 @@ except Exception:  # pragma: no cover - pillow-heif is optional
     pass
 
 from .media import scan_media
+from .face import detect_faces
+from .database import init_db, add_face_tag, search_by_name
 
 STATIC_DIR = Path(__file__).resolve().parents[1] / "frontend"
 app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="")
+init_db()
 
 
 @app.get("/api/media")
@@ -22,11 +26,11 @@ def api_media() -> object:
     """Return media files under a given directory as JSON.
 
     Each item includes the file ``path`` and, for images, a ``label`` from
-    the classifier.
+    the classifier. Logs from the scan are also returned.
     """
     path_str = request.args.get("path", ".")
-    files, skipped = scan_media(Path(path_str))
-    return jsonify({"files": files, "skipped": skipped})
+    files, skipped, logs = scan_media(Path(path_str))
+    return jsonify({"files": files, "skipped": skipped, "logs": logs})
 
 
 @app.get("/api/dirs")
@@ -57,6 +61,31 @@ def api_file() -> object:
             buf.seek(0)
             return send_file(buf, mimetype="image/jpeg")
     return send_file(path)
+
+
+@app.post("/api/tag")
+def api_tag() -> object:
+    data = request.get_json(force=True)
+    path = Path(data.get("path", ""))
+    name = data.get("name")
+    if not path or not name:
+        abort(400)
+    faces = detect_faces(path)
+    if not faces:
+        return jsonify({"status": "no-face"}), 400
+    add_face_tag(str(path), name, faces[0])
+    return jsonify({"status": "ok"})
+
+
+@app.get("/api/search")
+def api_search() -> object:
+    name = request.args.get("name")
+    if not name:
+        abort(400)
+    paths = search_by_name(name)
+    # return basic file records; labels will be looked up via DB by client if needed
+    files = [{"path": p} for p in paths]
+    return jsonify(files)
 
 
 @app.route("/")

--- a/gallery_organiser/server.py
+++ b/gallery_organiser/server.py
@@ -1,0 +1,70 @@
+"""Flask-based web interface for browsing media files."""
+from __future__ import annotations
+
+from pathlib import Path
+import io
+from flask import Flask, jsonify, request, send_from_directory, send_file, abort
+from PIL import Image
+try:
+    import pillow_heif
+    pillow_heif.register_heif_opener()  # enable HEIC support if installed
+except Exception:  # pragma: no cover - pillow-heif is optional
+    pass
+
+from .media import scan_media
+
+STATIC_DIR = Path(__file__).resolve().parents[1] / "frontend"
+app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="")
+
+
+@app.get("/api/media")
+def api_media() -> object:
+    """Return media files under a given directory as JSON.
+
+    Each item includes the file ``path`` and, for images, a ``label`` from
+    the classifier.
+    """
+    path_str = request.args.get("path", ".")
+    files, skipped = scan_media(Path(path_str))
+    return jsonify({"files": files, "skipped": skipped})
+
+
+@app.get("/api/dirs")
+def api_dirs() -> object:
+    """Return subdirectories for *path* as JSON."""
+    path_str = request.args.get("path", ".")
+    directory = Path(path_str)
+    dirs = [str(p) for p in directory.iterdir() if p.is_dir()]
+    return jsonify(dirs)
+
+
+@app.get("/api/file")
+def api_file() -> object:
+    """Send a media file to the browser.
+
+    HEIC images are converted to JPEG on the fly for browser compatibility.
+    """
+    path_str = request.args.get("path")
+    if not path_str:
+        abort(400)
+    path = Path(path_str)
+    if not path.exists():
+        abort(404)
+    if path.suffix.lower() == ".heic":
+        with Image.open(path) as img:
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG")
+            buf.seek(0)
+            return send_file(buf, mimetype="image/jpeg")
+    return send_file(path)
+
+
+@app.route("/")
+def index() -> object:
+    """Serve the React application."""
+    return send_from_directory(app.static_folder, "index.html")
+
+
+def run_server() -> None:
+    """Run the development server."""
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/gallery_organiser/server.py
+++ b/gallery_organiser/server.py
@@ -12,25 +12,38 @@ try:
 except Exception:  # pragma: no cover - pillow-heif is optional
     pass
 
-from .media import scan_media
 from .face import detect_faces
 from .database import init_db, add_face_tag, search_by_name
+from .tasks import scan_media_task
 
 STATIC_DIR = Path(__file__).resolve().parents[1] / "frontend"
 app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="")
 init_db()
 
 
-@app.get("/api/media")
-def api_media() -> object:
-    """Return media files under a given directory as JSON.
 
-    Each item includes the file ``path`` and, for images, a ``label`` from
-    the classifier. Logs from the scan are also returned.
-    """
-    path_str = request.args.get("path", ".")
-    files, skipped, logs = scan_media(Path(path_str))
-    return jsonify({"files": files, "skipped": skipped, "logs": logs})
+@app.post("/api/scan")
+def api_scan() -> object:
+    """Kick off a background scan task for *path*."""
+    data = request.get_json(force=True)
+    path_str = data.get("path", ".")
+    task = scan_media_task.delay(path_str)
+    return jsonify({"task_id": task.id})
+
+
+@app.get("/api/scan/<task_id>")
+def api_scan_status(task_id: str) -> object:
+    """Return status information for a scan task."""
+    task = scan_media_task.AsyncResult(task_id)
+    if task.state == "PENDING":
+        return jsonify({"state": "PENDING", "progress": 0})
+    if task.state == "FAILURE":
+        return jsonify({"state": "FAILURE", "error": str(task.info)}), 500
+    meta = task.info or {}
+    current = meta.get("current", 0)
+    total = meta.get("total", 1)
+    meta.update({"state": task.state, "progress": current / total if total else 0})
+    return jsonify(meta)
 
 
 @app.get("/api/dirs")

--- a/gallery_organiser/tasks.py
+++ b/gallery_organiser/tasks.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+from celery import Celery
+
+from .media import scan_media
+
+BROKER_URL = os.environ.get("CELERY_BROKER_URL", "memory://")
+RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "cache+memory://")
+celery_app = Celery(__name__, broker=BROKER_URL, backend=RESULT_BACKEND)
+celery_app.conf.update(
+    task_track_started=True,
+    task_always_eager=os.environ.get("CELERY_TASK_ALWAYS_EAGER", "1") == "1",
+    task_store_eager_result=True,
+)
+
+
+@celery_app.task(bind=True)
+def scan_media_task(self, path: str) -> Dict[str, object]:
+    """Scan *path* for media files and report progress."""
+    directory = Path(path)
+    files, skipped, logs, total = scan_media(
+        directory,
+        progress_cb=lambda cur, tot, recent: self.update_state(
+            state="PROGRESS", meta={"current": cur, "total": tot, "logs": recent}
+        ),
+    )
+    summary: Dict[str, int] = {}
+    for item in files:
+        label = item.get("label")
+        if label:
+            summary[label] = summary.get(label, 0) + 1
+    return {
+        "files": files,
+        "skipped": skipped,
+        "logs": logs,
+        "summary": summary,
+        "current": total,
+        "total": total,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pytest>=7.0
 Flask
 Pillow
 pillow-heif
-torch
-torchvision
+transformers
+opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow
 pillow-heif
 transformers
 opencv-python
+celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pytest>=7.0
+Flask
+Pillow
+pillow-heif
+torch
+torchvision

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser import cli, server
+
+
+def test_serve_command_invokes_run_server(monkeypatch):
+    called = {}
+
+    def fake_run_server():
+        called['ran'] = True
+
+    monkeypatch.setattr(server, 'run_server', fake_run_server)
+    cli.main(['serve'])
+    assert called.get('ran') is True
+
+
+def test_version_flag(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(['--version'])
+    assert '2.0.0' in capsys.readouterr().out

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -19,7 +19,7 @@ def test_scan_media(tmp_path, monkeypatch):
     (tmp_path / "doc.txt").write_text("a")
 
     monkeypatch.setattr(media, "classify_image", lambda p: "label")
-    files, skipped, logs = media.scan_media(tmp_path)
+    files, skipped, logs, _ = media.scan_media(tmp_path)
     names = sorted(Path(f["path"]).name for f in files)
     labels = [f.get("label") for f in files if f.get("label")]
     assert names == ["image.jpg", "photo.heic", "video.mp4"]
@@ -37,7 +37,7 @@ def test_scan_media_skips_inaccessible(tmp_path, monkeypatch):
         raise PermissionError
 
     monkeypatch.setattr(media, "classify_image", bad_classify)
-    files, skipped, logs = media.scan_media(tmp_path)
+    files, skipped, logs, _ = media.scan_media(tmp_path)
     assert files == []
     assert skipped == 1
     assert any("Skipped" in log for log in logs)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -3,25 +3,33 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from gallery_organiser import media
+from gallery_organiser import media, database
+
+
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "db.sqlite")
+    database.init_db()
 
 
 def test_scan_media(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
     (tmp_path / "image.jpg").write_text("a")
     (tmp_path / "video.mp4").write_text("a")
     (tmp_path / "photo.heic").write_text("a")
     (tmp_path / "doc.txt").write_text("a")
 
     monkeypatch.setattr(media, "classify_image", lambda p: "label")
-    files, skipped = media.scan_media(tmp_path)
+    files, skipped, logs = media.scan_media(tmp_path)
     names = sorted(Path(f["path"]).name for f in files)
     labels = [f.get("label") for f in files if f.get("label")]
     assert names == ["image.jpg", "photo.heic", "video.mp4"]
     assert labels == ["label", "label"]
     assert skipped == 0
+    assert any("Found" in log for log in logs)
 
 
 def test_scan_media_skips_inaccessible(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
     bad = tmp_path / "bad.jpg"
     bad.write_text("a")
 
@@ -29,6 +37,7 @@ def test_scan_media_skips_inaccessible(tmp_path, monkeypatch):
         raise PermissionError
 
     monkeypatch.setattr(media, "classify_image", bad_classify)
-    files, skipped = media.scan_media(tmp_path)
+    files, skipped, logs = media.scan_media(tmp_path)
     assert files == []
     assert skipped == 1
+    assert any("Skipped" in log for log in logs)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser import media
+
+
+def test_scan_media(tmp_path, monkeypatch):
+    (tmp_path / "image.jpg").write_text("a")
+    (tmp_path / "video.mp4").write_text("a")
+    (tmp_path / "photo.heic").write_text("a")
+    (tmp_path / "doc.txt").write_text("a")
+
+    monkeypatch.setattr(media, "classify_image", lambda p: "label")
+    files, skipped = media.scan_media(tmp_path)
+    names = sorted(Path(f["path"]).name for f in files)
+    labels = [f.get("label") for f in files if f.get("label")]
+    assert names == ["image.jpg", "photo.heic", "video.mp4"]
+    assert labels == ["label", "label"]
+    assert skipped == 0
+
+
+def test_scan_media_skips_inaccessible(tmp_path, monkeypatch):
+    bad = tmp_path / "bad.jpg"
+    bad.write_text("a")
+
+    def bad_classify(path: Path) -> str:
+        raise PermissionError
+
+    monkeypatch.setattr(media, "classify_image", bad_classify)
+    files, skipped = media.scan_media(tmp_path)
+    assert files == []
+    assert skipped == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is on the path when running tests directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gallery_organiser.models import Artwork, Gallery
+
+
+def test_add_and_list_artwork():
+    gallery = Gallery(name="Test")
+    art = Artwork(title="Mona Lisa", artist="Leonardo da Vinci", year=1503)
+    gallery.add_artwork(art)
+
+    artworks = gallery.list_artworks()
+    assert len(artworks) == 1
+    assert artworks[0].title == "Mona Lisa"
+    assert artworks[0].artist == "Leonardo da Vinci"
+    assert artworks[0].year == 1503

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,42 @@
+from gallery_organiser import server
+from PIL import Image
+
+def test_api_dirs(tmp_path):
+    (tmp_path / "sub").mkdir()
+    client = server.app.test_client()
+    resp = client.get("/api/dirs", query_string={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    assert str(tmp_path / "sub") in resp.get_json()
+
+
+def test_api_file(tmp_path):
+    img_path = tmp_path / "pic.png"
+    Image.new("RGB", (1, 1)).save(img_path)
+    client = server.app.test_client()
+    resp = client.get("/api/file", query_string={"path": str(img_path)})
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+
+
+def test_api_media(monkeypatch, tmp_path):
+    def fake_scan_media(path):
+        return ([{"path": str(tmp_path / "img.jpg"), "label": "cat"}], 0)
+
+    monkeypatch.setattr(server, "scan_media", fake_scan_media)
+    client = server.app.test_client()
+    resp = client.get("/api/media", query_string={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["files"][0]["label"] == "cat"
+    assert data["skipped"] == 0
+
+
+def test_run_server_uses_public_host(monkeypatch):
+    called = {}
+
+    def fake_run(*args, **kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(server.app, "run", fake_run)
+    server.run_server()
+    assert called.get("host") == "0.0.0.0"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,11 @@
-from gallery_organiser import server
+from gallery_organiser import server, database
 from PIL import Image
+
+
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "db.sqlite")
+    database.init_db()
+
 
 def test_api_dirs(tmp_path):
     (tmp_path / "sub").mkdir()
@@ -19,8 +25,10 @@ def test_api_file(tmp_path):
 
 
 def test_api_media(monkeypatch, tmp_path):
+    setup_db(tmp_path, monkeypatch)
+
     def fake_scan_media(path):
-        return ([{"path": str(tmp_path / "img.jpg"), "label": "cat"}], 0)
+        return ([{"path": str(tmp_path / "img.jpg"), "label": "cat"}], 0, ["log"])
 
     monkeypatch.setattr(server, "scan_media", fake_scan_media)
     client = server.app.test_client()
@@ -29,6 +37,24 @@ def test_api_media(monkeypatch, tmp_path):
     data = resp.get_json()
     assert data["files"][0]["label"] == "cat"
     assert data["skipped"] == 0
+    assert data["logs"] == ["log"]
+
+
+def test_tag_and_search(monkeypatch, tmp_path):
+    setup_db(tmp_path, monkeypatch)
+
+    def fake_detect(path):
+        return [(0, 0, 10, 10)]
+
+    monkeypatch.setattr(server, "detect_faces", fake_detect)
+    client = server.app.test_client()
+    img_path = tmp_path / "a.jpg"
+    img_path.write_text("a")
+    resp = client.post("/api/tag", json={"path": str(img_path), "name": "Bob"})
+    assert resp.status_code == 200
+    resp = client.get("/api/search", query_string={"name": "Bob"})
+    assert resp.status_code == 200
+    assert resp.get_json()[0]["path"] == str(img_path)
 
 
 def test_run_server_uses_public_host(monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
-from gallery_organiser import server, database
+from gallery_organiser import server, database, tasks, media
+from gallery_organiser import server, database, tasks, media
+from gallery_organiser import server, database, tasks, media
 from PIL import Image
-
 
 def setup_db(tmp_path, monkeypatch):
     monkeypatch.setattr(database, "DB_PATH", tmp_path / "db.sqlite")
@@ -24,20 +25,25 @@ def test_api_file(tmp_path):
     assert resp.mimetype == "image/png"
 
 
-def test_api_media(monkeypatch, tmp_path):
+def test_scan_endpoint(monkeypatch, tmp_path):
     setup_db(tmp_path, monkeypatch)
+    tasks.celery_app.conf.task_always_eager = True
 
-    def fake_scan_media(path):
-        return ([{"path": str(tmp_path / "img.jpg"), "label": "cat"}], 0, ["log"])
+    def fake_classify(path):
+        return "cat"
 
-    monkeypatch.setattr(server, "scan_media", fake_scan_media)
+    monkeypatch.setattr(media, "classify_image", fake_classify)
+    img = tmp_path / "a.jpg"
+    Image.new("RGB", (1, 1)).save(img)
     client = server.app.test_client()
-    resp = client.get("/api/media", query_string={"path": str(tmp_path)})
+    resp = client.post("/api/scan", json={"path": str(tmp_path)})
     assert resp.status_code == 200
+    task_id = resp.get_json()["task_id"]
+    resp = client.get(f"/api/scan/{task_id}")
     data = resp.get_json()
-    assert data["files"][0]["label"] == "cat"
-    assert data["skipped"] == 0
-    assert data["logs"] == ["log"]
+    assert data["state"] == "SUCCESS"
+    assert data["files"][0]["path"] == str(img)
+    assert data["summary"]["cat"] == 1
 
 
 def test_tag_and_search(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- skip unreadable files during media scans and report how many were skipped
- expose the skip count through `/api/media` and display loading/progress details in the React UI
- document the progress indicator and add tests for the new API shape

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python -m gallery_organiser add --title "Test" --artist "Tester"`
- `python -m gallery_organiser list`
- `python -m gallery_organiser serve` (queried `/api/media?path=/` then stopped)
- `python -m gallery_organiser --version`


------
https://chatgpt.com/codex/tasks/task_e_689b6e4dfaa08327b1baaac9e228d829